### PR TITLE
makeDraggable only if zoom enabled

### DIFF
--- a/src/JQVMap.js
+++ b/src/JQVMap.js
@@ -53,8 +53,6 @@ var JQVMap = function (params) {
   this.canvas = new VectorCanvas(this.width, this.height, params);
   params.container.append(this.canvas.canvas);
 
-  this.makeDraggable();
-
   this.rootGroup = this.canvas.createGroup(true);
 
   this.index = JQVMap.mapIndex;
@@ -63,6 +61,8 @@ var JQVMap = function (params) {
   if (params.enableZoom) {
     jQuery('<div/>').addClass('jqvmap-zoomin').text('+').appendTo(params.container);
     jQuery('<div/>').addClass('jqvmap-zoomout').html('&#x2212;').appendTo(params.container);
+    
+    this.makeDraggable();
   }
 
   map.countries = [];


### PR DESCRIPTION
#### What does this PR do ?

Prevents zooming on touch devices when `enableZoom` is `false`

#### How should this be tested ?

Drag is only need when `enableZoom` is `true`.

#### What are the relevant issues ?

Even with `enableZoom = false`, touch devices can still zoom the map if it's draggable.

#### This Pull Request includes:

- [x] Bug Fix with passing `npm test`
- [ ] New Feature with passing `npm test`
- [ ] Code Improvement with passing `npm test`
- [ ] Updated Documentation
- [ ] New Map File & Example HTML


