### PR TITLE
[Fix] booleano import error

### DIFF
--- a/create/jqvmap.py
+++ b/create/jqvmap.py
@@ -8,7 +8,9 @@ import os
 import copy
 from osgeo import ogr
 from osgeo import osr
-from booleano.parser import Grammar, EvaluableParseManager, SymbolTable, Bind
+from booleano.parser import Grammar
+from booleano.parser.core import EvaluableParseManager 
+from booleano.parser.scope import SymbolTable, Bind
 from booleano.operations import Variable
 
 

--- a/src/JQVMap.js
+++ b/src/JQVMap.js
@@ -61,7 +61,7 @@ var JQVMap = function (params) {
   if (params.enableZoom) {
     jQuery('<div/>').addClass('jqvmap-zoomin').text('+').appendTo(params.container);
     jQuery('<div/>').addClass('jqvmap-zoomout').html('&#x2212;').appendTo(params.container);
-    
+
     this.makeDraggable();
   }
 


### PR DESCRIPTION
#### What does this PR do ?

Fixes error:

```shell
:~/WWW/jqvmap/create$ python jqvmap.py config/country-name.json
Traceback (most recent call last):
  File "jqvmap.py", line 11, in <module>
    from booleano.parser import Grammar, EvaluableParseManager, SymbolTable, Bind
ImportError: cannot import name EvaluableParseManager
```

#### How should this be tested ?

With

- Python 2.7.12
- GDAL 2.1.3
- Shapely 1.2.16
- Booleano 1.1a2
  - pyparsing 2.2.0
  - six 1.10.0

Run

`python jqvmap.py config/country-name.json`

```json
// config/country-name.json

[
  {
    "name": "read_data",
    "file_name": "./source/gadm36_CUB_shp/gadm36_CUB_0.shp"
  },
  {
    "name": "write_data",
    "format": "jqvmap",
    "file_name": "./output/jquery.vmap.country-name.js",
    "params": {
      "code_field": "ISO",
      "name_field": "NAME_ENGLI",
      "name": "country-name"
    }
  }
]
```


#### What are the relevant issues ?

https://github.com/bjornd/jvectormap/issues/352#issuecomment-315216980

#### This Pull Request includes:

- [x] Bug Fix with passing `npm test`
- [ ] New Feature with passing `npm test`
- [ ] Code Improvement with passing `npm test`
- [ ] Updated Documentation
- [ ] New Map File & Example HTML

#### What gif best describes how you feel about this work ?

![cool](https://user-images.githubusercontent.com/3847077/39978398-2b140dd2-56f5-11e8-9052-91407721aeea.gif)
